### PR TITLE
Added PID json file for MiniCooperSE electric

### DIFF
--- a/Mini/MiniCooperSE.json
+++ b/Mini/MiniCooperSE.json
@@ -1,0 +1,71 @@
+{
+  "init_commands": {
+    "command": [
+	"ATZ", 
+	"ATD", 
+	"ATE0", 
+	"ATS0", 
+	"ATAL",
+	"ATPBE101",
+	"ATSPB",
+	"ATBI",
+	"ATSH6F1",
+	"ATAT0",
+	"ATSTFF"
+	]
+  },
+  "data_commands": {
+    "command": [
+      "ATCRA607",
+      "ATCEA07",
+      "ATFCSH6F1",
+      "ATFCSD07300800",
+      "ATFCSM1",
+      "22DDBC",
+      "22DD68",
+      "22DD69",
+      "226335"
+    ]
+  },
+  "obd_protocol": "B",
+  "soc": {
+    "equation": "(G*256+H)*0.1",
+    "minValue": "0",
+    "maxValue": "100",
+    "type": "Number",
+    "command": "22DDBC",
+    "ecu": "607"
+  },
+  "voltage": {
+    "equation": "(F*256+G)*0.01",
+    "minValue": "300",
+    "maxValue": "450",
+    "type": "Number",
+    "command": "22DD68",
+    "ecu": "607"
+  },
+  "current": {
+    "equation": "((signed(K)*256)+L)*0.01",
+    "minValue": "-300",
+    "maxValue": "300",
+    "type": "Number",
+    "command": "22DD69",
+    "ecu": "607"
+  },
+  "soh": {
+    "equation": "L",
+    "minValue": "0",
+    "maxValue": "100",
+    "type": "Number",
+    "command": "226335",
+    "ecu": "607"
+  },
+    "batt_temp": {
+    "equation": "(signed(M)*256+N)",
+    "minValue": "-40",
+    "maxValue": "80",
+    "type": "Number",
+    "command": "22DDC0",
+    "ecu": "607"
+  }
+}


### PR DESCRIPTION
The protocol "B" is unsure, could be 6 or 7 instead. "B" is entered because of the AT command "ATSPB" in the initialisation commands

The equations Letters are also unsure : example : received data for 22DDBC (soc) to module 607 is : 607F1100962DDBC01A6607F12103E50091FFFF 
that is interpreted by me as :
607 F1 10 09 62 DD BC 01 A6 607 F1 21 03 E5 00 91 FF FF
?      A  B  C    D   E    F    G   H    ?     I    J   K   L   M   N  O  P
the actual SOC is found in the 01 A6 pair. In my interpretation that is G + H : 01A6 in hex equals 422 in decimal. Divide by 10 to get the SOC : 42.2%
therefore the equation is (G*256+h)*0.1
if the 01 A6 pair is actually byte A and B the equation must be altered to (A*256+B)*0.1